### PR TITLE
Prevent accidental overwrites of exceptions during logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ OpenStax::RescueFrom.register_unrecognized_exception(SecurityTransgression)
 # when used with example above, the above example's options will prevail
 ```
 
-*Note:* You *must* use a function that accepts `exception` as an argument for `extras`
+**Note:** You **must** use a function that accepts `exception` as an argument for `extras`
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,31 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+## Registering Exceptions
+
+```ruby
+# Use OpenStax::RescueFrom.register_exception(exception_constant_or_string, options = {})
+# to register new exceptions or override the options of existing ones
+
+OpenStax::RescueFrom.register_exception(SecurityTransgression, notify: true,
+                                                               status: 500,
+                                                               extras: -> (exception) {
+                                                                 { headers: exception.response.headers }
+                                                               })
+
+OpenStax::RescueFrom.register_exception('ActiveRecord::RecordNotFound', notify: false,
+                                                                        status: 403)
+
+# Use OpenStax::RescueFrom.register_unrecognized_exception(exception_constant_or_string, options = {})
+# to register ONLY unrecognized exceptions, to avoid accidental overwriting of options
+
+OpenStax::RescueFrom.register_unrecognized_exception(SecurityTransgression)
+
+# when used with example above, the above example's options will prevail
+```
+
+*Note:* You *must* use a function that accepts `exception` as an argument for `extras`
+
 ## Configuration
 
 This configuration, which is placed in `./config/initializers/rescue_from.rb` by the install generator, shows the defaults:

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -7,11 +7,8 @@ module OpenStax
   module RescueFrom
     class << self
       def perform_rescue(exception, listener = MuteListener.new)
-        unless registered_exceptions.keys.include?(exception.class.name)
-          register_exception(exception.class)
-        end
-
         proxy = ExceptionProxy.new(exception)
+        register_unrecognized_exception(proxy.name)
         log_system_error(proxy)
         send_notifying_exceptions(proxy, listener)
         finish_exception_rescue(proxy, listener)
@@ -21,6 +18,12 @@ module OpenStax
         name = exception.is_a?(String) ? exception : exception.name
         @@registered_exceptions ||= {}
         @@registered_exceptions[name] = ExceptionOptions.new(options)
+      end
+
+      def register_unrecognized_exception(exception_class)
+        unless registered_exceptions.keys.include?(exception_class)
+          register_exception(exception_class)
+        end
       end
 
       def translate_status_codes(map = {})

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -20,9 +20,9 @@ module OpenStax
         @@registered_exceptions[name] = ExceptionOptions.new(options)
       end
 
-      def register_unrecognized_exception(exception_class)
+      def register_unrecognized_exception(exception_class, options = {})
         unless registered_exceptions.keys.include?(exception_class)
-          register_exception(exception_class)
+          register_exception(exception_class, options)
         end
       end
 

--- a/lib/openstax/rescue_from/logger.rb
+++ b/lib/openstax/rescue_from/logger.rb
@@ -18,7 +18,7 @@ module OpenStax
       private
       def record_system_error_recursively!
         if @proxy = proxy.cause
-          RescueFrom.register_exception(proxy.name)
+          RescueFrom.register_unrecognized_exception(proxy.name)
           record_system_error!("Exception cause")
         end
       end


### PR DESCRIPTION
Logger had some OBE code that could have overwritten existing registered exception causes with default options. A new public class method will now be available to register only exceptions that are unrecognized. It's public because Logger needs to use it, and I see no reason why we couldn't provide this behavior to the end-user in case they have some use for a method that doesn't accidentally overwrite previously registered exceptions.