### PR TITLE
Closes #20 Allow developer to set a custom :message to override the status code mapped value

### DIFF
--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -16,8 +16,11 @@ module OpenStax
 
       def register_exception(exception, options = {})
         name = exception.is_a?(String) ? exception : exception.name
+        options = ExceptionOptions.new(options)
         @@registered_exceptions ||= {}
-        @@registered_exceptions[name] = ExceptionOptions.new(options)
+        @@friendly_status_messages ||= {}
+        @@registered_exceptions[name] = options
+        @@friendly_status_messages[name] = options.message if options.message
       end
 
       def register_unrecognized_exception(exception_class, options = {})
@@ -44,8 +47,10 @@ module OpenStax
         @@registered_exceptions.select { |_, v| v.notify? }.keys
       end
 
-      def friendly_message(status)
-        friendly_status_messages[status] || default_friendly_message
+      def friendly_message(exception)
+        friendly_status_messages[exception.name] ||
+          friendly_status_messages[exception.status] ||
+            default_friendly_message
       end
 
       def notifies_for?(exception_name)

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -18,9 +18,7 @@ module OpenStax
         name = exception.is_a?(String) ? exception : exception.name
         options = ExceptionOptions.new(options)
         @@registered_exceptions ||= {}
-        @@friendly_status_messages ||= {}
         @@registered_exceptions[name] = options
-        @@friendly_status_messages[name] = options.message if options.message
       end
 
       def register_unrecognized_exception(exception_class, options = {})
@@ -47,9 +45,9 @@ module OpenStax
         @@registered_exceptions.select { |_, v| v.notify? }.keys
       end
 
-      def friendly_message(exception)
-        friendly_status_messages[exception.name] ||
-          friendly_status_messages[exception.status] ||
+      def friendly_message(proxy)
+        options_for(proxy.name).message ||
+          friendly_status_messages[proxy.status] ||
             default_friendly_message
       end
 
@@ -82,6 +80,10 @@ module OpenStax
       end
 
       private
+      def options_for(name)
+        @@registered_exceptions[name]
+      end
+
       def friendly_status_messages
         @@friendly_status_messages ||= {
           internal_server_error: default_friendly_message,

--- a/lib/openstax/rescue_from/exception_options.rb
+++ b/lib/openstax/rescue_from/exception_options.rb
@@ -1,16 +1,18 @@
 module OpenStax
   module RescueFrom
     class ExceptionOptions
-      attr_accessor :notify, :status_code, :extras
+      attr_accessor :notify, :status_code, :message, :extras
 
       def initialize(options = {})
         options.stringify_keys!
         options = { 'notify' => true,
                     'status' => :internal_server_error,
+                    'message' => nil,
                     'extras' => ->(exception) { {} } }.merge(options)
 
         @notify = options['notify']
         @status_code = options['status']
+        @message = options['message']
         @extras = options['extras']
       end
 

--- a/lib/openstax/rescue_from/exception_proxy.rb
+++ b/lib/openstax/rescue_from/exception_proxy.rb
@@ -20,7 +20,7 @@ module OpenStax
       end
 
       def friendly_message
-        RescueFrom.friendly_message(status)
+        RescueFrom.friendly_message(self)
       end
 
       def extras

--- a/spec/controllers/controller_spec.rb
+++ b/spec/controllers/controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 require './spec/support/test_controller'
 
+class CustomError < StandardError; end
+
 module Test
   RSpec.describe TestController do
     before do
@@ -110,6 +112,20 @@ module Test
       expect(assigns[:message]).to eq(
         "Sorry, RescueFrom Dummy App had some unexpected trouble with your request."
       )
+    end
+
+    context 'custom messages override status code messages' do
+      before { OpenStax::RescueFrom.configure { |c| c.raise_exceptions = false } }
+
+      it 'allows the developer to set a custom message' do
+        OpenStax::RescueFrom.register_exception(CustomError,
+                                                message: 'This dang custom error')
+
+        get :bad_action, exception: 'CustomError'
+
+        expect(assigns[:code]).to eq(500)
+        expect(assigns[:message]).to eq('This dang custom error')
+      end
     end
   end
 end


### PR DESCRIPTION
I'm not entirely pleased with this code... something feels tangled about it. Could use some help sniffing out the code smells...