### PR TITLE
Fix exception when logging exceptions with causes

### DIFF
--- a/lib/openstax/rescue_from/exception_proxy.rb
+++ b/lib/openstax/rescue_from/exception_proxy.rb
@@ -28,11 +28,7 @@ module OpenStax
       end
 
       def cause
-        @cause ||= if exception.respond_to?(:cause) && exception.cause
-                     ExceptionCauseProxy.new(exception.cause)
-                   else
-                     nil
-                   end
+        @cause ||= exception.cause if exception.respond_to?(:cause)
       end
 
       def logger_backtrace

--- a/lib/openstax/rescue_from/logger.rb
+++ b/lib/openstax/rescue_from/logger.rb
@@ -20,7 +20,7 @@ module OpenStax
       def record_system_error_recursively!
         if exception_proxy.cause
           RescueFrom.register_exception(exception_proxy.cause.class)
-          @exception_proxy = ExceptionProxy.new(exception_proxy.cause)
+          @exception_proxy = ExceptionCauseProxy.new(exception_proxy.cause)
           record_system_error!("Exception cause")
         end
       end

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end

--- a/spec/lib/openstax/rescue_from/logger_spec.rb
+++ b/spec/lib/openstax/rescue_from/logger_spec.rb
@@ -24,8 +24,10 @@ module OpenStax
 
             allow(described_class).to receive(:new) { logger }
             expect(logger).to receive(:record_system_error!).with(no_args).once.and_call_original
-            expect(logger).to receive(:record_system_error_recursively!).once.and_call_original
-            expect(logger).to receive(:record_system_error!).with("Exception cause").once
+            expect(logger).to receive(:record_system_error_recursively!).twice.and_call_original
+            expect(logger).to(
+              receive(:record_system_error!).with("Exception cause").once.and_call_original
+            )
 
             RescueFrom.perform_rescue(exception)
           end


### PR DESCRIPTION
Due to double-wrapping the exception in `record_system_error_recursively!`