### PR TITLE
Configurable exception notifier (sentry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,16 +93,77 @@ OpenStax::RescueFrom.configure do |config|
   # Can be a name, or a web/email address. See 'View helper' below
   config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
-  # To use ExceptionNotifier, after adding `gem 'exception_notification'` to your Gemfile:
-  # config.notifier = ExceptionNotifier
-  # config.notify_method = :notify_exception
+  # To use ExceptionNotifier add `gem 'exception_notification'` to your Gemfile and then:
+  # config.notify_proc = ->(proxy, controller) do
+  #   ExceptionNotifier.notify_exception(
+  #     proxy.exception,
+  #     env: controller.request.env,
+  #     data: {
+  #       error_id: proxy.error_id,
+  #       class: proxy.name,
+  #       message: proxy.message,
+  #       first_line_of_backtrace: proxy.first_backtrace_line,
+  #       cause: proxy.cause,
+  #       dns_name: resolve_ip(controller.request.remote_ip),
+  #       extras: proxy.extras
+  #     },
+  #     sections: %w(data request session environment backtrace)
+  #   )
+  # end
+  # config.notify_background_proc = ->(proxy) do
+  #   ExceptionNotifier.notify_exception(
+  #     proxy.exception,
+  #     data: {
+  #       error_id: proxy.error_id,
+  #       class: proxy.name,
+  #       message: proxy.message,
+  #       first_line_of_backtrace: proxy.first_backtrace_line,
+  #       cause: proxy.cause,
+  #       extras: proxy.extras
+  #     },
+  #     sections: %w(data environment backtrace)
+  #   )
+  # end
+  # config.notify_rack_middleware = ExceptionNotification::Rack,
+  # config.notify_rack_middleware_options = {
+  #   email: {
+  #     email_prefix: RescueFrom.configuration.email_prefix,
+  #     sender_address: RescueFrom.configuration.sender_address,
+  #     exception_recipients: RescueFrom.configuration.exception_recipients
+  #   }
+  # }
   # URL generation errors are caused by bad routes, for example, and should not be ignored
   # ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 
-  # To use Raven (Sentry), after adding `gem 'sentry-raven', require: 'raven/base'`
-  # to your Gemfile:
-  # config.notifier = Raven
-  # config.notify_method = :capture_type
+  # To use Raven (Sentry) add `gem 'sentry-raven', require: 'raven/base'` to your Gemfile and then:
+  # config.notify_proc = -> do |proxy, controller|
+  #   extra = {
+  #     env: controller.request.env,
+  #     error_id: proxy.error_id,
+  #     class: proxy.name,
+  #     message: proxy.message,
+  #     first_line_of_backtrace: proxy.first_backtrace_line,
+  #     cause: proxy.cause,
+  #     dns_name: resolve_ip(controller.request.remote_ip)
+  #   }
+  #   extra.merge!(proxy.extras) if proxy.extras.is_a? Hash
+  #
+  #   Raven.capture_exception(proxy.exception, extra: extra)
+  # end
+  # config.notify_background_proc = -> do |proxy|
+  #   extra = {
+  #     error_id: proxy.error_id,
+  #     class: proxy.name,
+  #     message: proxy.message,
+  #     first_line_of_backtrace: proxy.first_backtrace_line,
+  #     cause: proxy.cause
+  #   }
+  #   extra.merge!(proxy.extras) if proxy.extras.is_a? Hash
+  #
+  #   Raven.capture_exception(proxy.exception, extra: extra)
+  # end
+  # require 'raven/integrations/rack'
+  # config.notify_rack_middleware = Raven::Rack
 
   config.html_error_template_path = 'errors/any'
   config.html_error_template_layout_name = 'application'

--- a/README.md
+++ b/README.md
@@ -90,10 +90,19 @@ OpenStax::RescueFrom.configure do |config|
 
   config.app_name = ENV['APP_NAME']
   config.app_env = ENV['APP_ENV']
+  # Can be a name, or a web/email address. See 'View helper' below
   config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
-    # can be a name, or a web/email address. See 'View helper' below
 
-  config.notifier = ExceptionNotifier
+  # To use ExceptionNotifier, after adding `gem 'exception_notification'` to your Gemfile:
+  # config.notifier = ExceptionNotifier
+  # config.notify_method = :notify_exception
+  # URL generation errors are caused by bad routes, for example, and should not be ignored
+  # ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
+
+  # To use Raven (Sentry), after adding `gem 'sentry-raven', require: 'raven/base'`
+  # to your Gemfile:
+  # config.notifier = Raven
+  # config.notify_method = :capture_type
 
   config.html_error_template_path = 'errors/any'
   config.html_error_template_layout_name = 'application'

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ OpenStax::RescueFrom.configure do |config|
                               Rails.application.config.consider_all_requests_local
 
   config.app_name = ENV['APP_NAME']
-  config.app_env = ENV['APP_ENV']
   # Can be a name, or a web/email address. See 'View helper' below
   config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
@@ -124,12 +123,12 @@ OpenStax::RescueFrom.configure do |config|
   #     sections: %w(data environment backtrace)
   #   )
   # end
-  # config.notify_rack_middleware = ExceptionNotification::Rack,
+  # config.notify_rack_middleware = ExceptionNotification::Rack
   # config.notify_rack_middleware_options = {
   #   email: {
-  #     email_prefix: RescueFrom.configuration.email_prefix,
-  #     sender_address: RescueFrom.configuration.sender_address,
-  #     exception_recipients: RescueFrom.configuration.exception_recipients
+  #     email_prefix: "[#{config.app_name}] (#{ENV['APP_ENV']}) ",
+  #     sender_address: ENV['EXCEPTION_SENDER'],
+  #     exception_recipients: ENV['EXCEPTION_RECIPIENTS']
   #   }
   # }
   # URL generation errors are caused by bad routes, for example, and should not be ignored
@@ -166,10 +165,6 @@ OpenStax::RescueFrom.configure do |config|
 
   config.html_error_template_path = 'errors/any'
   config.html_error_template_layout_name = 'application'
-
-  config.email_prefix = "[#{app_name}] (#{app_env}) "
-  config.sender_address = ENV['EXCEPTION_SENDER']
-  config.exception_recipients = ENV['EXCEPTION_RECIPIENTS']
 end
 
 # Exceptions in controllers might be reraised or not depending on the settings above
@@ -177,9 +172,6 @@ ActionController::Base.use_openstax_exception_rescue
 
 # RescueFrom always reraises background exceptions so that the background job may properly fail
 ActiveJob::Base.use_openstax_exception_rescue
-
-# URL generation errors are caused by bad routes, for example, and should not be ignored
-ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 ```
 
 ## Controller hook

--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ OpenStax::RescueFrom.configure do |config|
   # To use Raven (Sentry) add `gem 'sentry-raven', require: 'raven/base'` to your Gemfile and then:
   # config.notify_proc = -> do |proxy, controller|
   #   extra = {
-  #     env: controller.request.env,
   #     error_id: proxy.error_id,
   #     class: proxy.name,
   #     message: proxy.message,

--- a/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
+++ b/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
@@ -11,15 +11,77 @@ OpenStax::RescueFrom.configure do |config|
   # config.app_env = ENV['APP_ENV']
   # config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
-  # To use ExceptionNotifier, after adding `gem 'exception_notification'` to your Gemfile:
-  # config.notifier = ExceptionNotifier
-  # config.notify_method = :notify_exception
+  # To use ExceptionNotifier add `gem 'exception_notification'` to your Gemfile and then:
+  # config.notify_proc = ->(proxy, controller) do
+  #   ExceptionNotifier.notify_exception(
+  #     proxy.exception,
+  #     env: controller.request.env,
+  #     data: {
+  #       error_id: proxy.error_id,
+  #       class: proxy.name,
+  #       message: proxy.message,
+  #       first_line_of_backtrace: proxy.first_backtrace_line,
+  #       cause: proxy.cause,
+  #       dns_name: resolve_ip(controller.request.remote_ip),
+  #       extras: proxy.extras
+  #     },
+  #     sections: %w(data request session environment backtrace)
+  #   )
+  # end
+  # config.notify_background_proc = ->(proxy) do
+  #   ExceptionNotifier.notify_exception(
+  #     proxy.exception,
+  #     data: {
+  #       error_id: proxy.error_id,
+  #       class: proxy.name,
+  #       message: proxy.message,
+  #       first_line_of_backtrace: proxy.first_backtrace_line,
+  #       cause: proxy.cause,
+  #       extras: proxy.extras
+  #     },
+  #     sections: %w(data environment backtrace)
+  #   )
+  # end
+  # config.notify_rack_middleware = ExceptionNotification::Rack,
+  # config.notify_rack_middleware_options = {
+  #   email: {
+  #     email_prefix: RescueFrom.configuration.email_prefix,
+  #     sender_address: RescueFrom.configuration.sender_address,
+  #     exception_recipients: RescueFrom.configuration.exception_recipients
+  #   }
+  # }
   # URL generation errors are caused by bad routes, for example, and should not be ignored
   # ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 
-  # To use Raven (Sentry), after adding `gem 'sentry-raven', require: 'raven/base'` to your Gemfile:
-  # config.notifier = Raven
-  # config.notify_method = :capture_type
+  # To use Raven (Sentry) add `gem 'sentry-raven', require: 'raven/base'` to your Gemfile and then:
+  # config.notify_proc = -> do |proxy, controller|
+  #   extra = {
+  #     env: controller.request.env,
+  #     error_id: proxy.error_id,
+  #     class: proxy.name,
+  #     message: proxy.message,
+  #     first_line_of_backtrace: proxy.first_backtrace_line,
+  #     cause: proxy.cause,
+  #     dns_name: resolve_ip(controller.request.remote_ip)
+  #   }
+  #   extra.merge!(proxy.extras) if proxy.extras.is_a? Hash
+  #
+  #   Raven.capture_exception(proxy.exception, extra: extra)
+  # end
+  # config.notify_background_proc = -> do |proxy|
+  #   extra = {
+  #     error_id: proxy.error_id,
+  #     class: proxy.name,
+  #     message: proxy.message,
+  #     first_line_of_backtrace: proxy.first_backtrace_line,
+  #     cause: proxy.cause
+  #   }
+  #   extra.merge!(proxy.extras) if proxy.extras.is_a? Hash
+  #
+  #   Raven.capture_exception(proxy.exception, extra: extra)
+  # end
+  # require 'raven/integrations/rack'
+  # config.notify_rack_middleware = Raven::Rack
 
   # config.html_error_template_path = 'errors/any'
   # config.html_error_template_layout_name = 'application'

--- a/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
+++ b/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
@@ -56,7 +56,6 @@ OpenStax::RescueFrom.configure do |config|
   # To use Raven (Sentry) add `gem 'sentry-raven', require: 'raven/base'` to your Gemfile and then:
   # config.notify_proc = -> do |proxy, controller|
   #   extra = {
-  #     env: controller.request.env,
   #     error_id: proxy.error_id,
   #     class: proxy.name,
   #     message: proxy.message,

--- a/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
+++ b/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
@@ -11,7 +11,15 @@ OpenStax::RescueFrom.configure do |config|
   # config.app_env = ENV['APP_ENV']
   # config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
+  # To use ExceptionNotifier, after adding `gem 'exception_notification'` to your Gemfile:
   # config.notifier = ExceptionNotifier
+  # config.notify_method = :notify_exception
+  # URL generation errors are caused by bad routes, for example, and should not be ignored
+  # ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
+
+  # To use Raven (Sentry), after adding `gem 'sentry-raven', require: 'raven/base'` to your Gemfile:
+  # config.notifier = Raven
+  # config.notify_method = :capture_type
 
   # config.html_error_template_path = 'errors/any'
   # config.html_error_template_layout_name = 'application'
@@ -26,9 +34,6 @@ ActionController::Base.use_openstax_exception_rescue
 
 # RescueFrom always reraises background exceptions so that the background job may properly fail
 ActiveJob::Base.use_openstax_exception_rescue
-
-# URL generation errors are caused by bad routes, for example, and should not be ignored
-ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 
 # OpenStax::RescueFrom.translate_status_codes(
 #   internal_server_error: "Sorry, #{OpenStax::RescueFrom.configuration.app_name} had some unexpected trouble with your request.",

--- a/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
+++ b/lib/generators/openstax/rescue_from/install/templates/rescue_from.rb
@@ -8,7 +8,6 @@ OpenStax::RescueFrom.configure do |config|
   )
 
   # config.app_name = ENV['APP_NAME']
-  # config.app_env = ENV['APP_ENV']
   # config.contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
   # To use ExceptionNotifier add `gem 'exception_notification'` to your Gemfile and then:
@@ -42,12 +41,12 @@ OpenStax::RescueFrom.configure do |config|
   #     sections: %w(data environment backtrace)
   #   )
   # end
-  # config.notify_rack_middleware = ExceptionNotification::Rack,
+  # config.notify_rack_middleware = ExceptionNotification::Rack
   # config.notify_rack_middleware_options = {
   #   email: {
-  #     email_prefix: RescueFrom.configuration.email_prefix,
-  #     sender_address: RescueFrom.configuration.sender_address,
-  #     exception_recipients: RescueFrom.configuration.exception_recipients
+  #     email_prefix: "[#{config.app_name}] (#{ENV['APP_ENV']}) ",
+  #     sender_address: ENV['EXCEPTION_SENDER'],
+  #     exception_recipients: ENV['EXCEPTION_RECIPIENTS']
   #   }
   # }
   # URL generation errors are caused by bad routes, for example, and should not be ignored
@@ -84,10 +83,6 @@ OpenStax::RescueFrom.configure do |config|
 
   # config.html_error_template_path = 'errors/any'
   # config.html_error_template_layout_name = 'application'
-
-  # config.email_prefix = "[#{app_name}] (#{app_env}) "
-  # config.sender_address = ENV['EXCEPTION_SENDER']
-  # config.exception_recipients = ENV['EXCEPTION_RECIPIENTS']
 end
 
 # Exceptions in controllers might be reraised or not depending on the settings above

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -151,43 +151,15 @@ module OpenStax
       end
 
       def send_notifying_exceptions(proxy, controller)
-        return if configuration.notifier.blank? || configuration.notify_method.blank? ||
-                  !configuration.notify_exceptions || !notifies_for?(proxy.name)
+        return if !configuration.notify_exceptions || !notifies_for?(proxy.name)
 
-        configuration.notifier.public_send(
-          configuration.notify_method,
-          proxy.exception,
-          env: controller.request.env,
-          data: {
-            error_id: proxy.error_id,
-            class: proxy.name,
-            message: proxy.message,
-            first_line_of_backtrace: proxy.first_backtrace_line,
-            cause: proxy.cause,
-            dns_name: resolve_ip(controller.request.remote_ip),
-            extras: proxy.extras
-          },
-          sections: %w(data request session environment backtrace)
-        )
+        instance_exec(proxy, controller, &configuration.notify_proc)
       end
 
       def send_notifying_background_exceptions(proxy)
-        return if configuration.notifier.blank? || configuration.notify_method.blank? ||
-                  !configuration.notify_background_exceptions || !notifies_for?(proxy.name)
+        return if !configuration.notify_background_exceptions || !notifies_for?(proxy.name)
 
-        configuration.notifier.public_send(
-          configuration.notify_method,
-          proxy.exception,
-          data: {
-            error_id: proxy.error_id,
-            class: proxy.name,
-            message: proxy.message,
-            first_line_of_backtrace: proxy.first_backtrace_line,
-            cause: proxy.cause,
-            extras: proxy.extras
-          },
-          sections: %w(data environment backtrace)
-        )
+        instance_exec(proxy, &configuration.notify_background_proc)
       end
 
       def finish_exception_rescue(proxy, listener)

--- a/lib/openstax/rescue_from/configuration.rb
+++ b/lib/openstax/rescue_from/configuration.rb
@@ -1,5 +1,3 @@
-require 'exception_notification'
-
 module OpenStax
   module RescueFrom
     class Configuration
@@ -7,8 +5,7 @@ module OpenStax
       attr_accessor :raise_exceptions, :raise_background_exceptions, :notify_exceptions,
         :notify_proc, :notify_background_exceptions, :notify_background_proc,
         :notify_rack_middleware, :notify_rack_middleware_options,
-        :html_error_template_path, :html_error_template_layout_name, :app_name, :app_env,
-        :email_prefix, :sender_address, :exception_recipients
+        :html_error_template_path, :html_error_template_layout_name, :app_name
 
       attr_writer :contact_name
 
@@ -23,7 +20,6 @@ module OpenStax
         )
 
         @app_name = ENV['APP_NAME']
-        @app_env = ENV['APP_ENV']
         @contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
         @notify_exceptions = true
@@ -33,18 +29,6 @@ module OpenStax
 
         @html_error_template_path = 'errors/any'
         @html_error_template_layout_name = 'application'
-
-        @sender_address = ENV['EXCEPTION_SENDER']
-        @exception_recipients = ENV['EXCEPTION_RECIPIENTS']
-      end
-
-      def email_prefix
-        return(@email_prefix) if defined?(@email_prefix) && !@email_prefix.blank?
-
-        name = app_name.blank? ? nil : "[#{app_name}]"
-        env = app_env.blank? ? nil : "(#{app_env}) "
-
-        @email_prefix = [name, env].compact.join(' ')
       end
     end
   end

--- a/lib/openstax/rescue_from/configuration.rb
+++ b/lib/openstax/rescue_from/configuration.rb
@@ -5,6 +5,7 @@ module OpenStax
     class Configuration
 
       attr_accessor :raise_exceptions, :raise_background_exceptions, :notifier,
+        :notify_method, :notify_exceptions, :notify_background_exceptions,
         :html_error_template_path, :html_error_template_layout_name, :app_name,
         :app_env, :email_prefix, :sender_address, :exception_recipients
 
@@ -24,7 +25,8 @@ module OpenStax
         @app_env = ENV['APP_ENV']
         @contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
-        @notifier = ExceptionNotifier
+        @notify_exceptions = true
+        @notify_background_exceptions = true
 
         @html_error_template_path = 'errors/any'
         @html_error_template_layout_name = 'application'

--- a/lib/openstax/rescue_from/configuration.rb
+++ b/lib/openstax/rescue_from/configuration.rb
@@ -4,10 +4,11 @@ module OpenStax
   module RescueFrom
     class Configuration
 
-      attr_accessor :raise_exceptions, :raise_background_exceptions, :notifier,
-        :notify_method, :notify_exceptions, :notify_background_exceptions,
-        :html_error_template_path, :html_error_template_layout_name, :app_name,
-        :app_env, :email_prefix, :sender_address, :exception_recipients
+      attr_accessor :raise_exceptions, :raise_background_exceptions, :notify_exceptions,
+        :notify_proc, :notify_background_exceptions, :notify_background_proc,
+        :notify_rack_middleware, :notify_rack_middleware_options,
+        :html_error_template_path, :html_error_template_layout_name, :app_name, :app_env,
+        :email_prefix, :sender_address, :exception_recipients
 
       attr_writer :contact_name
 
@@ -26,7 +27,9 @@ module OpenStax
         @contact_name = ENV['EXCEPTION_CONTACT_NAME']
 
         @notify_exceptions = true
+        @notify_proc = ->(proxy, controller) {}
         @notify_background_exceptions = true
+        @notify_background_proc = ->(proxy) {}
 
         @html_error_template_path = 'errors/any'
         @html_error_template_layout_name = 'application'

--- a/lib/openstax/rescue_from/engine.rb
+++ b/lib/openstax/rescue_from/engine.rb
@@ -9,12 +9,16 @@ module OpenStax
         end
       end
 
-      initializer "openstax.rescue_from.use_exception_notification_middleware" do
-        Rails.application.config.middleware.use ExceptionNotification::Rack, email: {
-          email_prefix: RescueFrom.configuration.email_prefix,
-          sender_address: RescueFrom.configuration.sender_address,
-          exception_recipients: RescueFrom.configuration.exception_recipients
-        }
+      initializer "openstax.rescue_from.use_rack_middleware" do
+        middleware = OpenStax::RescueFrom.configuration.notify_rack_middleware
+        next if middleware.blank?
+
+        options = OpenStax::RescueFrom.configuration.notify_rack_middleware_options
+        if options.nil?
+          Rails.application.config.middleware.insert 0, middleware
+        else
+          Rails.application.config.middleware.insert 0, middleware, options
+        end
       end
 
       initializer "openstax.rescue_from.pre_register_exceptions" do

--- a/lib/openstax/rescue_from/engine.rb
+++ b/lib/openstax/rescue_from/engine.rb
@@ -15,9 +15,9 @@ module OpenStax
 
         options = OpenStax::RescueFrom.configuration.notify_rack_middleware_options
         if options.nil?
-          Rails.application.config.middleware.insert 0, middleware
+          Rails.application.config.middleware.insert_before 0, middleware
         else
-          Rails.application.config.middleware.insert 0, middleware, options
+          Rails.application.config.middleware.insert_before 0, middleware, options
         end
       end
 

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = "2.1.0"
+    VERSION = "3.0.0"
   end
 end

--- a/openstax_rescue_from.gemspec
+++ b/openstax_rescue_from.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rails-controller-testing"
   spec.add_development_dependency "database_cleaner"
+  spec.add_development_dependency "exception_notification"
 end

--- a/openstax_rescue_from.gemspec
+++ b/openstax_rescue_from.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.0'
 
   spec.add_dependency "rails", '>= 3.1', '< 6.0'
-  spec.add_dependency "exception_notification", '>= 4.1', '< 5.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pg"

--- a/spec/dummy/config/initializers/rescue_from.rb
+++ b/spec/dummy/config/initializers/rescue_from.rb
@@ -1,21 +1,56 @@
 require_relative '../../../support/exceptions_list'
 require 'openstax_rescue_from'
+require 'exception_notification'
 
 OpenStax::RescueFrom.configure do |config|
   config.raise_exceptions = false
 
   config.app_name = 'RescueFrom Dummy App'
-  config.app_env = 'DUM'
   config.contact_name = 'RescueFromDummy.com'
 
-  # config.notifier = ExceptionNotifier
+  config.notify_proc = ->(proxy, controller) do
+    ExceptionNotifier.notify_exception(
+      proxy.exception,
+      env: controller.request.env,
+      data: {
+        error_id: proxy.error_id,
+        class: proxy.name,
+        message: proxy.message,
+        first_line_of_backtrace: proxy.first_backtrace_line,
+        cause: proxy.cause,
+        dns_name: resolve_ip(controller.request.remote_ip),
+        extras: proxy.extras
+      },
+      sections: %w(data request session environment backtrace)
+    )
+  end
+  config.notify_background_proc = ->(proxy) do
+    ExceptionNotifier.notify_exception(
+      proxy.exception,
+      data: {
+        error_id: proxy.error_id,
+        class: proxy.name,
+        message: proxy.message,
+        first_line_of_backtrace: proxy.first_backtrace_line,
+        cause: proxy.cause,
+        extras: proxy.extras
+      },
+      sections: %w(data environment backtrace)
+    )
+  end
+  config.notify_rack_middleware = ExceptionNotification::Rack
+  config.notify_rack_middleware_options = {
+    email: {
+      email_prefix: "[#{config.app_name}] (DUM) ",
+      sender_address: 'donotreply@dummyapp.com',
+      exception_recipients: 'notify@dummyapp.com'
+    }
+  }
+  # URL generation errors are caused by bad routes, for example, and should not be ignored
+  ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 
   # config.html_error_template_path = 'errors/any'
   # config.html_error_template_layout_name = 'application'
-
-  # config.email_prefix = "[#{app_name}] (#{app_env}) "
-  config.sender_address = 'donotreply@dummyapp.com'
-  config.exception_recipients = 'notify@dummyapp.com'
 end
 
 # Exceptions in controllers might be reraised or not depending on the settings above
@@ -23,9 +58,6 @@ ActionController::Base.use_openstax_exception_rescue
 
 # RescueFrom always reraises background exceptions so that the background job may properly fail
 ActiveJob::Base.use_openstax_exception_rescue
-
-# URL generation errors are caused by bad routes, for example, and should not be ignored
-ExceptionNotifier.ignored_exceptions.delete("ActionController::UrlGenerationError")
 
 OpenStax::RescueFrom.translate_status_codes({
   forbidden: "You are not allowed to access this.",

--- a/spec/jobs/active_job_spec.rb
+++ b/spec/jobs/active_job_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe ActiveJob do
       expect(mail.from).to eq(['donotreply@dummyapp.com'])
       expect(mail.to).to eq(['notify@dummyapp.com'])
       expect(mail.subject).to eq(
-        '[RescueFrom Dummy App] (DUM) (StandardError) "StandardError"'
+        '[RescueFrom Dummy App] (DUM)  (StandardError) "StandardError"'
       )
     end
   end


### PR DESCRIPTION
- Allow specifying the notify_method and whether to notify for foreground and background exceptions
- No longer require exception_notification in the gemspec
- Configuring the notifier is now required