### PR TITLE
Rescue ActionController::UnknownFormat with a 404

### DIFF
--- a/lib/openstax/rescue_from/default_exceptions.rb
+++ b/lib/openstax/rescue_from/default_exceptions.rb
@@ -10,6 +10,10 @@ module OpenStax
                                       notify: false,
                                       status: :not_found)
 
+        RescueFrom.register_exception(ActionController::UnknownFormat,	
+                                      notify: false,
+                                      status: :not_found)
+
         RescueFrom.register_exception(ActionController::InvalidAuthenticityToken,
                                       notify: false,
                                       status: :unprocessable_entity)

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = "4.0.0"
+    VERSION = '4.0.1'
   end
 end


### PR DESCRIPTION
Otherwise the server returns a 500 error for missing images etc that get caught by the catch-all route.