### PR TITLE
Don't log background exceptions that have notify: false

### DIFF
--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -139,13 +139,15 @@ module OpenStax
       end
 
       def log_system_error(proxy)
-        if notifies_for?(proxy.name)
-          logger = Logger.new(proxy)
-          logger.record_system_error!
-        end
+        return unless notifies_for?(proxy.name)
+
+        logger = Logger.new(proxy)
+        logger.record_system_error!
       end
 
       def log_background_system_error(proxy)
+        return unless notifies_for?(proxy.name)
+
         logger = Logger.new(proxy)
         logger.record_system_error!('A background job exception occurred')
       end

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = '4.1.0'
+    VERSION = '4.2.0'
   end
 end


### PR DESCRIPTION
Tutor wants to use this to disable logging of PG::LockWaitTimeout errors