### PR TITLE
CORE-381 Prevent record_system_error! from clobbering the config for exceptions that are in the cause field of another exception

### DIFF
--- a/lib/openstax/rescue_from/logger.rb
+++ b/lib/openstax/rescue_from/logger.rb
@@ -19,7 +19,7 @@ module OpenStax
       private
       def record_system_error_recursively!
         if exception_proxy.cause
-          RescueFrom.register_exception(exception_proxy.cause.class)
+          RescueFrom.register_unrecognized_exception(exception_proxy.cause.class)
           @exception_proxy = ExceptionCauseProxy.new(exception_proxy.cause)
           record_system_error!("Exception cause")
         end

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = '4.2.1'
+    VERSION = '4.2.2'
   end
 end


### PR DESCRIPTION
...by using `register_unrecognized_exception` which has a guard against overwriting existing config.

This was causing intermittent test failures in Accounts.
It may or may not also fix us getting a 500 error instead of a 404 in Accounts, since that's what was happening in the test (the config for `ActiveRecord::RecordNotFound` was being overwritten when processing a `DeserializationError` that had an `ActiveRecord::RecordNotFound` as the cause).