### PR TITLE
Stop registering unrecognized exceptions at all

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,19 +62,6 @@ OpenStax::RescueFrom.register_exception(SecurityTransgression, status: 403,
 
 OpenStax::RescueFrom.register_exception('ActiveRecord::RecordNotFound', notify: false,
                                                                         status: 404)
-
-# Use OpenStax::RescueFrom.register_unrecognized_exception(exception_constant_or_string, options = {})
-# to register ONLY unrecognized exceptions, to avoid accidental overwriting of options
-
-OpenStax::RescueFrom.register_unrecognized_exception(SecurityTransgression)
-
-# when used with example above, the above example's options will prevail
-
-# Default options:
-#
-# { notify: true,
-#   status: :internal_server_error,
-#   extras: ->(exception) { {} } }
 ```
 
 **Note:** If you want to define `extras`, you **must** use a function that accepts `exception` as its argument

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -76,7 +76,7 @@ module OpenStax
       end
 
       def notifies_for?(exception_name)
-        notifying_exceptions.include?(exception_name)
+        options_for(exception_name).notify?
       end
 
       def status(exception_name)

--- a/lib/openstax/rescue_from.rb
+++ b/lib/openstax/rescue_from.rb
@@ -9,7 +9,6 @@ module OpenStax
     class << self
       def perform_rescue(exception, listener = MuteListener.new)
         proxy = ExceptionProxy.new(exception)
-        register_unrecognized_exception(proxy.name)
         log_system_error(proxy)
         send_notifying_exceptions(proxy, listener)
         finish_exception_rescue(proxy, listener)
@@ -17,7 +16,6 @@ module OpenStax
 
       def perform_background_rescue(exception, listener = MuteListener.new)
         proxy = ExceptionProxy.new(exception)
-        register_unrecognized_exception(proxy.name)
         log_background_system_error(proxy)
         send_notifying_background_exceptions(proxy)
         finish_background_exception_rescue(proxy, listener)
@@ -42,12 +40,6 @@ module OpenStax
         options = ExceptionOptions.new(options)
         @@registered_exceptions ||= {}
         @@registered_exceptions[name] = options
-      end
-
-      def register_unrecognized_exception(exception_class, options = {})
-        unless registered_exceptions.keys.include?(exception_class)
-          register_exception(exception_class, options)
-        end
       end
 
       # For rescuing from specific blocks of code: OpenStax::RescueFrom.this {...}
@@ -88,11 +80,11 @@ module OpenStax
       end
 
       def status(exception_name)
-        @@registered_exceptions[exception_name].status_code
+        options_for(exception_name).status_code
       end
 
       def sorry(exception_name)
-        @@registered_exceptions[exception_name].sorry
+        options_for(exception_name).sorry
       end
 
       def http_code(status)
@@ -100,7 +92,7 @@ module OpenStax
       end
 
       def extras_proc(exception_name)
-        @@registered_exceptions[exception_name].extras
+        options_for(exception_name).extras
       end
 
       def generate_id
@@ -116,8 +108,9 @@ module OpenStax
       end
 
       private
+
       def options_for(name)
-        @@registered_exceptions[name]
+        @@registered_exceptions[name] || ExceptionOptions.new
       end
 
       def friendly_status_messages

--- a/lib/openstax/rescue_from/logger.rb
+++ b/lib/openstax/rescue_from/logger.rb
@@ -19,7 +19,6 @@ module OpenStax
       private
       def record_system_error_recursively!
         if exception_proxy.cause
-          RescueFrom.register_unrecognized_exception(exception_proxy.cause.class)
           @exception_proxy = ExceptionCauseProxy.new(exception_proxy.cause)
           record_system_error!("Exception cause")
         end

--- a/lib/openstax/rescue_from/version.rb
+++ b/lib/openstax/rescue_from/version.rb
@@ -1,5 +1,5 @@
 module OpenStax
   module RescueFrom
-    VERSION = '4.2.2'
+    VERSION = '4.3.0'
   end
 end

--- a/spec/lib/openstax/rescue_from_spec.rb
+++ b/spec/lib/openstax/rescue_from_spec.rb
@@ -70,21 +70,21 @@ RSpec.describe OpenStax::RescueFrom do
 
     context '#log_background_system_error' do
       it 'logs notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
-
         expect(OpenStax::RescueFrom::Logger).to receive(:new).and_call_original
         expect_any_instance_of(OpenStax::RescueFrom::Logger).to(
           receive(:record_system_error!).with('A background job exception occurred')
         )
 
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
         described_class.send :log_background_system_error, proxy
       end
 
       it 'does not log non-notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test', notify: false)
-        OpenStax::RescueFrom.register_exception proxy.name
+        OpenStax::RescueFrom.register_exception ActiveRecord::RecordNotFound, notify: false
 
         expect(OpenStax::RescueFrom::Logger).not_to receive(:new)
+
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test')
         described_class.send :log_background_system_error, proxy
       end
     end
@@ -117,20 +117,21 @@ RSpec.describe OpenStax::RescueFrom do
 
     context '#log_system_error' do
       it 'logs notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
-        OpenStax::RescueFrom.register_exception proxy.name
+        OpenStax::RescueFrom.register_exception StandardError
 
         expect(OpenStax::RescueFrom::Logger).to receive(:new).and_call_original
         expect_any_instance_of(OpenStax::RescueFrom::Logger).to receive(:record_system_error!)
 
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
         described_class.send :log_system_error, proxy
       end
 
       it 'does not log non-notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test', notify: false)
-        OpenStax::RescueFrom.register_exception proxy.name
+        OpenStax::RescueFrom.register_exception ActiveRecord::RecordNotFound, notify: false
 
         expect(OpenStax::RescueFrom::Logger).not_to receive(:new)
+
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test', notify: false)
         described_class.send :log_system_error, proxy
       end
     end

--- a/spec/lib/openstax/rescue_from_spec.rb
+++ b/spec/lib/openstax/rescue_from_spec.rb
@@ -71,7 +71,6 @@ RSpec.describe OpenStax::RescueFrom do
     context '#log_background_system_error' do
       it 'logs notifying exceptions' do
         proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
-        OpenStax::RescueFrom.register_unrecognized_exception proxy.name
 
         expect(OpenStax::RescueFrom::Logger).to receive(:new).and_call_original
         expect_any_instance_of(OpenStax::RescueFrom::Logger).to(
@@ -82,8 +81,8 @@ RSpec.describe OpenStax::RescueFrom do
       end
 
       it 'does not log non-notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test')
-        OpenStax::RescueFrom.register_unrecognized_exception proxy.name
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test', notify: false)
+        OpenStax::RescueFrom.register_exception proxy.name
 
         expect(OpenStax::RescueFrom::Logger).not_to receive(:new)
         described_class.send :log_background_system_error, proxy
@@ -119,7 +118,7 @@ RSpec.describe OpenStax::RescueFrom do
     context '#log_system_error' do
       it 'logs notifying exceptions' do
         proxy = OpenStax::RescueFrom::ExceptionProxy.new(StandardError.new 'test')
-        OpenStax::RescueFrom.register_unrecognized_exception proxy.name
+        OpenStax::RescueFrom.register_exception proxy.name
 
         expect(OpenStax::RescueFrom::Logger).to receive(:new).and_call_original
         expect_any_instance_of(OpenStax::RescueFrom::Logger).to receive(:record_system_error!)
@@ -128,8 +127,8 @@ RSpec.describe OpenStax::RescueFrom do
       end
 
       it 'does not log non-notifying exceptions' do
-        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test')
-        OpenStax::RescueFrom.register_unrecognized_exception proxy.name
+        proxy = OpenStax::RescueFrom::ExceptionProxy.new(ActiveRecord::RecordNotFound.new 'test', notify: false)
+        OpenStax::RescueFrom.register_exception proxy.name
 
         expect(OpenStax::RescueFrom::Logger).not_to receive(:new)
         described_class.send :log_system_error, proxy


### PR DESCRIPTION
Modifying class variables after initialization is usually considered bad, so I'm hoping that by removing this we stop these exception rescues from randomly failing in Accounts and throwing 500 errors instead.